### PR TITLE
Build TSC on install

### DIFF
--- a/express/package.json
+++ b/express/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "postinstall": "npm run build",
     "prepublish": "npm run build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Builds TSC when installing via `npm`

Tested via: 

```
npm install 'https://gitpkg.now.sh/sidpremkumar/decipher-client-js/express?main'
```

Built output
![2024-03-28 at 8 08 PM](https://github.com/decipherai/decipher-client-js/assets/28202162/774cbb08-b6ae-4086-a7e2-92d96a7dfd86)
